### PR TITLE
Remove temporary text about slog integration, since slog has been integrated with production-ready `log/slog`

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,4 @@ drivers have been implemented:
 - Olivier Poitrey's `zerolog` - adapter that uses [`github.com/rs/zerolog`](https://pkg.go.dev/github.com/rs/zerolog)
   logger for logs output. Instantiate it with `adapter/zerolog.New(...)`.
 - (Future) Stdlib `slog` - adapter that uses [`golang.org/x/exp/slog`](https://pkg.go.dev/golang.org/x/exp/slog)
-  logger for logs output. Instantiate it with `adapter/slog.New(...)`. Adapter is expected to be
-  [included into stdlib](https://github.com/golang/go/issues/56345), once it is there - dependency will be changed from
-  `golang.org/x/exp/slog` to `log/slog` or whenever it will land.
+  logger for logs output. Instantiate it with `adapter/slog.New(...)`.


### PR DESCRIPTION
I propose to remove notice about slog integration from `README.md` file.

Since log/slog has been released to Golang 1.21 and it's located by path `log/slog` and `gue` successfully integration release `log/slog` into slog's adapter I think ` Adapter is expected to be included into stdlib, once it is there - dependency will be changed from `golang.org/x/exp/slog` to `log/slog` or whenever it will land.` text can be removed from `README.md` file.